### PR TITLE
Use Homebrew provider for build on OS X.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.3-
 BinDeps 0.3.1
 Distance
+@osx Homebrew

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -7,6 +7,15 @@ libflann = library_dependency("libflann", aliases = ["libflann1.8", "flann.dll",
 
 provides(AptGet, {"libflann1.8" => libflann})
 provides(Yum, {"$flann_version-2" => libflann})
+
+@osx_only begin
+    if Pkg.installed("Homebrew") === nothing
+        error("Homebrew package not installed, please run Pkg.add(\"Homebrew\")")
+	end
+    using Homebrew
+    provides( Homebrew.HB, "flann", libflann, os = :Darwin )
+end
+
 provides(Sources, URI("http://www.cs.ubc.ca/research/flann/uploads/FLANN/$flann_version-src.zip"),	libflann)
 
 flannusrdir = BinDeps.usrdir(libflann)


### PR DESCRIPTION
If using Homebrew, FLANN will now be installed as a binary on OS X (it was just added to the juliadeps binary repository).
