### PR TITLE
Use Homebrew provider for build on OS X.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,15 @@
-language: cpp
-compiler:
-  - clang
+language: julia
+os:
+  - linux
+  - osx
+julia:
+  - release
+  - nightly
 notifications:
   email: false
-before_install:
-  - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-  - sudo add-apt-repository ppa:staticfloat/julianightlies -y
-  - sudo apt-get update -qq -y
-  - sudo apt-get install libpcre3-dev julia -y
 script:
   - julia -e 'Pkg.init(); Pkg.clone(pwd()); Pkg.resolve();'
   - julia -e 'Pkg.build("FLANN")'
   - julia -e 'Pkg.test("FLANN", coverage=true)'
 after_success:
   - julia -e 'cd(Pkg.dir("FLANN")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 FLANN.jl [![Build Status](https://travis-ci.org/wildart/FLANN.jl.svg)](https://travis-ci.org/wildart/FLANN.jl) [![Coverage Status](https://img.shields.io/coveralls/wildart/FLANN.jl.svg)](https://coveralls.io/r/wildart/FLANN.jl?branch=master)
 ========
-A simple wrapper for [FLANN](http://www.cs.ubc.ca/research/flann/), Fast Library for Approximate Nearest Neighbors. It has similar to the [NearestNeighbors](https://github.com/wildart/NearestNeighbors.jl) package API.
+A simple wrapper for [FLANN](http://www.cs.ubc.ca/research/flann/), Fast Library for Approximate Nearest Neighbors. It has an interface similar to the [NearestNeighbors](https://github.com/wildart/NearestNeighbors.jl) package API.
 
 # Installation
 Clone package from this repository and build it.
@@ -9,7 +9,7 @@ Clone package from this repository and build it.
 	julia> Pkg.build("FLANN")
 
 ## Linux
-Depending on the verison of your operation system, you'll be propmted to install a FLANN binary or it is going be build from the sources.
+Depending on the version of your operation system, you'll be prompted to install a FLANN binary or it is going be built from the sources.
 
 # Usage Example
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.3-
 BinDeps 0.3.1
 Distances
+@osx Homebrew

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -7,6 +7,15 @@ libflann = library_dependency("libflann", aliases = ["libflann1.8", "flann.dll",
 
 provides(AptGet, {"libflann1.8" => libflann})
 provides(Yum, {"$flann_version-2" => libflann})
+
+@osx_only begin
+    if Pkg.installed("Homebrew") === nothing
+        error("Homebrew package not installed, please run Pkg.add(\"Homebrew\")")
+	end
+    using Homebrew
+    provides( Homebrew.HB, "flann", libflann, os = :Darwin )
+end
+
 provides(Sources, URI("http://www.cs.ubc.ca/research/flann/uploads/FLANN/$flann_version-src.zip"),	libflann)
 
 flannusrdir = BinDeps.usrdir(libflann)


### PR DESCRIPTION
If using Homebrew, FLANN will now be installed as a binary on OS X (it was just added to the juliadeps binary repository).

Rebased to master.
