### PR TITLE
knn! and inrange! for preallocated outputs

### DIFF
--- a/src/FLANN.jl
+++ b/src/FLANN.jl
@@ -12,7 +12,7 @@ else
     error("FLANN not properly installed. Please run Pkg.build(\"FLANN\")")
 end
 
-export FLANNParameters, flann, addpoints!, removepoint!, knn, inrange
+export FLANNParameters, flann, addpoints!, removepoint!, knn, inrange, knn!, inrange!
 
 include("params.jl")
 include("wrapper.jl")

--- a/test/testflann.jl
+++ b/test/testflann.jl
@@ -58,6 +58,25 @@ module TestFLANN
     idxs, dsts = inrange(model, x, 1.0, max_nn)
     @test size(idxs) == (max_nn, )
 
+    # preallocated inrange! and knn! tests
+    idxs = fill(Cint(-1), k)
+    dists = fill(eltype(X)(-1), k)
+    knn!(X, x, k, params, idxs, dists)
+    @test all(idxs .>= 1)
+    @test all(dists .>= 0)
+
+    idxs = fill(Cint(-1), k)
+    dists = fill(eltype(X)(-1), k)
+    knn!(model, x, k, idxs, dists)
+    @test all(idxs .>= 1)
+    @test all(dists .>= 0)
+
+    idxs = fill(Cint(-1), k)
+    dists = fill(eltype(X)(-1), k)
+    idxs_view, dists_view = inrange!(model, x, r^2, max_nn, idxs, dists)
+    @test all(idxs_view .>= 1)
+    @test all(dists_view .>= 0)
+
     # close model
     close(model)
 


### PR DESCRIPTION
Added knn! and inrange! that populate preallocated output vectors of indices and distances.