### PR TITLE
Julia 1.0 compatibility, dropping 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
 julia:
   - 0.7
   - 1.0
+  - 1.1
   - nightly
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,10 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
+  - 0.7
+  - 1.0
   - nightly
 notifications:
   email: false
-script:
-  - julia -e 'Pkg.init(); Pkg.clone(pwd()); Pkg.resolve();'
-  - julia -e 'Pkg.build("FLANN")'
-  - julia -e 'Pkg.test("FLANN", coverage=true)'
 after_success:
-  - julia -e 'cd(Pkg.dir("FLANN")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+  - julia --project -e 'import Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,20 @@
+name = "FLANN"
+uuid = "4ef67f76-e0de-5105-ac01-03b6482fb4f8"
+version = "1.0.0"
+
+[deps]
+BinDeps = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
+Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[compat]
+BinDeps = "≥ 0.8.10"
+Distances = "≥ 0.7.2"
+julia = "≥ 0.7.0"
+
+[extras]
+DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["DelimitedFiles", "Test"]

--- a/README.md
+++ b/README.md
@@ -1,19 +1,11 @@
-FLANN.jl [![Build Status](https://travis-ci.org/wildart/FLANN.jl.svg)](https://travis-ci.org/wildart/FLANN.jl) [![Coverage Status](https://img.shields.io/coveralls/wildart/FLANN.jl.svg)](https://coveralls.io/r/wildart/FLANN.jl?branch=master)
+FLANN.jl [![Build Status](https://travis-ci.org/wildart/FLANN.jl.svg?branch=master)](https://travis-ci.org/wildart/FLANN.jl) [![Coverage Status](https://coveralls.io/repos/wildart/FLANN.jl/badge.svg?branch=master)](https://coveralls.io/r/wildart/FLANN.jl?branch=master)
 ========
 A simple wrapper for [FLANN](http://www.cs.ubc.ca/research/flann/), Fast Library for Approximate Nearest Neighbors. It has an interface similar to the [NearestNeighbors](https://github.com/KristofferC/NearestNeighbors.jl) package API.
 
 # Installation
-Use the package manager to install
+Use the package manager to install:
 
-	julia> Pkg.add("FLANN")
-
-or clone the package from this repository and build it.
-
-	julia> Pkg.clone("https://github.com/wildart/FLANN.jl.git")
-	julia> Pkg.build("FLANN")
-
-## Linux
-Depending on the version of your operation system, you'll be prompted to install a FLANN binary or it is going be built from the sources.
+	pkg> add FLANN
 
 # Usage Example
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.6
-BinDeps
-Distances
+julia 0.7
+BinDeps 0.8.10
+Distances 0.7.2

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,0 @@
-julia 0.7
-BinDeps 0.8.10
-Distances 0.7.2

--- a/deps/.gitignore
+++ b/deps/.gitignore
@@ -2,4 +2,5 @@ builds/
 downloads/
 src/
 usr/
+build.log
 deps.jl

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,4 +1,5 @@
 using BinDeps
+using Libdl
 
 @BinDeps.setup
 

--- a/src/FLANN.jl
+++ b/src/FLANN.jl
@@ -18,7 +18,7 @@ include("params.jl")
 include("wrapper.jl")
 
 # Interface compatible with Distances package
-function flann(X::Matrix, p::FLANNParameters, metric::PreMetric)
+function flann(X::AbstractMatrix, p::FLANNParameters, metric::PreMetric)
     m, o = FLANNMetric(metric)
     return flann(X, p, m, o)
 end

--- a/src/params.jl
+++ b/src/params.jl
@@ -35,7 +35,7 @@ const FLANN_DIST_HAMMING_LUT		= 10
 const FLANN_DIST_HAMMING_POPCNT   	= 11
 const FLANN_DIST_L2_SIMPLE	   		= 12
 
-immutable FLANNParameters
+struct FLANNParameters
     algorithm::Cint  		# the algorithm to use
 
     # search time parameters

--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -112,7 +112,9 @@ function knn!(X::Matrix{T}, xs::AbstractVecOrMat{T}, k, p::FLANNParameters, inds
 
     @assert res == 0 "Search failed!"
 
-    inds .= inds .+ 1
+    @inbounds for i in 1:k
+        inds[i] = inds[i] + 1
+    end
     return inds, dists
 end
 
@@ -154,7 +156,9 @@ function knn!(index::FLANNIndex{T}, xs::AbstractVecOrMat{T}, k, inds::VecOrMat{C
 
     @assert res == 0 "Search failed!"
 
-    inds .= inds .+ 1
+    @inbounds for i in 1:k
+        inds[i] = inds[i] + 1
+    end
     return inds, dists
 end
 

--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -27,7 +27,7 @@ function getmetric()
 end
 
 "This function constructs a near neighbor search index for a given dataset (columns of `X` correspond to points)."
-function flann(X::Matrix{T}, p::FLANNParameters, metric::Int = FLANN_DIST_EUCLIDEAN, order::Int = 2) where T<:FLANN_DataTypes
+function flann(X::AbstractMatrix{T}, p::FLANNParameters, metric::Int = FLANN_DIST_EUCLIDEAN, order::Int = 2) where T<:FLANN_DataTypes
     c, r = size(X)
     speedup = fill(Cfloat(0))
     setmetric(Cint(metric), Cint(order))
@@ -86,7 +86,7 @@ function Base.write(filename::AbstractString, index::FLANNIndex)
 end
 
 "This function loads a previously saved index from a file. Since the dataset is not saved with the index, it must be provided to this function."
-function Base.read(filename::AbstractString, X::Matrix{T}, p::FLANNParameters, metric::Int = FLANN_DIST_EUCLIDEAN, order::Int = 2) where T<:FLANN_DataTypes
+function Base.read(filename::AbstractString, X::AbstractMatrix{T}, p::FLANNParameters, metric::Int = FLANN_DIST_EUCLIDEAN, order::Int = 2) where T<:FLANN_DataTypes
     c, r = size(X)
     index = _read(filename, X, r, c)
     return FLANNIndex{T}(c, index, p, metric, order)
@@ -94,7 +94,7 @@ end
 
 "This function builds a search index and uses it to find the `k` nearest neighbors of `xs` points using an already built `index`.
 Results are stored in the preallocated arrays `inds` and dists`."
-function knn!(X::Matrix{T}, xs::AbstractVecOrMat{T}, k, p::FLANNParameters, inds::VecOrMat{Cint}, dists) where T<:FLANN_DataTypes
+function knn!(X::AbstractMatrix{T}, xs::AbstractVecOrMat{T}, k, p::FLANNParameters, inds::AbstractVecOrMat{Cint}, dists) where T<:FLANN_DataTypes
     @assert size(xs, 1) == size(X, 1) "Dataset and query set of different dimensionality"
     @assert eltype(dists) == (T == Cdouble ? Cdouble : Cfloat)
 
@@ -119,7 +119,7 @@ function knn!(X::Matrix{T}, xs::AbstractVecOrMat{T}, k, p::FLANNParameters, inds
 end
 
 "This function builds a search index and uses it to find the `k` nearest neighbors of `xs` points using an already built `index`."
-function knn(X::Matrix{T}, xs::AbstractVecOrMat{T}, k, p::FLANNParameters) where T<:FLANN_DataTypes
+function knn(X::AbstractMatrix{T}, xs::AbstractVecOrMat{T}, k, p::FLANNParameters) where T<:FLANN_DataTypes
     @assert size(xs, 1) == size(X, 1) "Dataset and query set of different dimensionality"
 
     distancetype = T == Cdouble ? Cdouble : Cfloat
@@ -139,7 +139,7 @@ end
 
 "This function searches for the `k` nearest neighbors of `xs` points using an already built `index`.
 Results are stored in the preallocated arrays `inds` and dists`."
-function knn!(index::FLANNIndex{T}, xs::AbstractVecOrMat{T}, k, inds::VecOrMat{Cint}, dists) where T<:FLANN_DataTypes
+function knn!(index::FLANNIndex{T}, xs::AbstractVecOrMat{T}, k, inds::AbstractVecOrMat{Cint}, dists) where T<:FLANN_DataTypes
     @assert size(xs, 1) == index.dim "Dataset and query set of different dimensionality"
     @assert eltype(dists) == (T == Cdouble ? Cdouble : Cfloat)
 
@@ -183,7 +183,7 @@ end
 
 "This function performs a radius search from a single query point to points in an already built `index`.
 Results are stored in the preallocated arrays `inds` and dists`; `SubArray`s of appropriate length are returned."
-function inrange!(index::FLANNIndex{T}, x::AbstractVector{T}, r2::Real, max_nn::Int, inds::Vector{Cint}, dists::Vector) where T<:FLANN_DataTypes
+function inrange!(index::FLANNIndex{T}, x::AbstractVector{T}, r2::Real, max_nn::Int, inds::AbstractVector{Cint}, dists::AbstractVector) where T<:FLANN_DataTypes
     @assert length(x) == index.dim "Dataset and query point of different dimensionality"
     @assert eltype(dists) == (T == Cdouble ? Cdouble : Cfloat)
 
@@ -226,7 +226,7 @@ function Base.close(index::FLANNIndex)
 end
 
 for (T, Tname) in ((Cfloat, "float"), (Cdouble, "double"), (Cint, "int"), (Cuchar, "byte"))
-    @eval @inline function _flann(X::Matrix{$T}, r, c, speedup, flann_params)
+    @eval @inline function _flann(X::AbstractMatrix{$T}, r, c, speedup, flann_params)
         ccall(($("flann_build_index_" * Tname), libflann), Ptr{Cvoid},
               (Ptr{$T}, Cint, Cint, Ptr{Cfloat}, Ptr{Cvoid}), X, r, c, speedup, flann_params)
     end
@@ -260,24 +260,24 @@ for (T, Tname) in ((Cfloat, "float"), (Cdouble, "double"), (Cint, "int"), (Cucha
               (Ptr{Cvoid}, Cstring), index.index, filename)
     end
 
-    @eval @inline function _read(filename, X::Matrix{$T}, r, c)
+    @eval @inline function _read(filename, X::AbstractMatrix{$T}, r, c)
         ccall(($("flann_load_index_" * Tname), libflann), Ptr{Cvoid},
               (Cstring, Ptr{$T}, Cint, Cint), filename, X, r, c)
     end
 
-    @eval @inline function _knn(X::Matrix{$T}, r, c, xs, trows, inds, dists::Array{S}, k, flann_params) where S
+    @eval @inline function _knn(X::AbstractMatrix{$T}, r, c, xs, trows, inds, dists::AbstractArray{S}, k, flann_params) where S
         ccall(($("flann_find_nearest_neighbors_" * Tname), libflann), Cint,
               (Ptr{$T}, Cint, Cint, Ptr{$T}, Cint, Ptr{Cint}, Ptr{S}, Cint, Ptr{Cvoid}),
               X, r, c, xs, trows, inds, dists, k, flann_params)
     end
 
-    @eval @inline function _knn(index::FLANNIndex{$T}, xs, trows, inds, dists::Array{S}, k, flann_params) where S
+    @eval @inline function _knn(index::FLANNIndex{$T}, xs, trows, inds, dists::AbstractArray{S}, k, flann_params) where S
         ccall(($("flann_find_nearest_neighbors_index_" * Tname), libflann), Cint,
               (Ptr{Cvoid}, Ptr{$T}, Cint, Ptr{Cint}, Ptr{S}, Cint, Ptr{Cvoid}),
               index.index, xs, trows, inds, dists, k, flann_params)
     end
 
-    @eval @inline function _inrange(index::FLANNIndex{$T}, x, inds, dists::Array{S}, max_nn, r2, flann_params) where S
+    @eval @inline function _inrange(index::FLANNIndex{$T}, x, inds, dists::AbstractArray{S}, max_nn, r2, flann_params) where S
         ccall(($("flann_radius_search_" * Tname), libflann), Cint,
               (Ptr{Cvoid}, Ptr{$T}, Ptr{Cint}, Ptr{S}, Cint, Cfloat, Ptr{Cvoid}),
               index.index, x, inds, dists, max_nn, r2, flann_params)

--- a/test/testflann.jl
+++ b/test/testflann.jl
@@ -1,5 +1,6 @@
 module TestFLANN
-    using Base.Test
+    using Test
+    using DelimitedFiles
     using FLANN
 
     # load test data

--- a/test/testflann.jl
+++ b/test/testflann.jl
@@ -99,6 +99,16 @@ module TestFLANN
     # close model
     close(model)
 
+    # testing flann for AbstractArray
+    traindata = reshape(reinterpret(Float64, [(x, x, x) for x in (.1:.1:1)]), 3, 10)
+    model = flann(traindata, FLANNParameters(checks = -1, trees = 1))
+    @test knn(model, .47*ones(3), 2)[1] == [5,4]
+    @test length(model) == 10
+    @test model[5] == .5*ones(3)
+
+    # close model
+    close(model)
+
     # using Distances package for metrics
     using Distances
     metric = JSDivergence()


### PR DESCRIPTION
Mostly just find/replace stuff; I didn't think carefully about whether any of the logic should be updated to better fit julia 1.0 features.

This PR will only work for julia 0.7+. To maintain 0.6 compatibility, I propose that a release be tagged for the current state of this repo (e.g., v0.2.0), and then another release be tagged after this PR is accepted/merged (e.g., v1.0.0).